### PR TITLE
register items with a DeferredRegistry, and into a creative tab

### DIFF
--- a/src/main/java/com/tarinoita/solsweetpotato/SOLSweetPotato.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/SOLSweetPotato.java
@@ -1,19 +1,15 @@
 package com.tarinoita.solsweetpotato;
 
 import com.tarinoita.solsweetpotato.client.ContainerScreenRegistry;
-import com.tarinoita.solsweetpotato.client.SOLClientRegistry;
 import com.tarinoita.solsweetpotato.communication.ConfigMessage;
 import com.tarinoita.solsweetpotato.communication.FoodListMessage;
+import com.tarinoita.solsweetpotato.item.SOLSweetPotatoItems;
 import com.tarinoita.solsweetpotato.item.foodcontainer.FoodContainerScreen;
-
 import net.minecraft.client.gui.screens.MenuScreens;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -21,8 +17,6 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.simple.SimpleChannel;
-import net.minecraftforge.registries.DeferredRegister;
-import net.minecraftforge.registries.RegistryObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,12 +61,23 @@ public final class SOLSweetPotato
 	}
 
 	@SubscribeEvent
+	public static void buildCreativeTab(BuildCreativeModeTabContentsEvent event) {
+		if (event.getTabKey() == CreativeModeTabs.FOOD_AND_DRINKS) {
+			event.accept(SOLSweetPotatoItems.FOOD_BOOK.get());
+			event.accept(SOLSweetPotatoItems.LUNCHBOX.get());
+			event.accept(SOLSweetPotatoItems.LUNCHBAG.get());
+			event.accept(SOLSweetPotatoItems.GOLDEN_LUNCHBOX.get());
+		}
+	}
+
+	@SubscribeEvent
 	public static void setupClient(FMLClientSetupEvent event) {
 		event.enqueueWork(() -> { MenuScreens.register(ContainerScreenRegistry.FOOD_CONTAINER.get(), FoodContainerScreen::new); });
 	}
 
 	public SOLSweetPotato() {
 		SOLSweetPotatoConfig.setUp();
+		SOLSweetPotatoItems.REGISTER.register(FMLJavaModLoadingContext.get().getModEventBus());
 		ContainerScreenRegistry.MENU_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
 	}
 }

--- a/src/main/java/com/tarinoita/solsweetpotato/item/SOLSweetPotatoItems.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/item/SOLSweetPotatoItems.java
@@ -2,31 +2,17 @@ package com.tarinoita.solsweetpotato.item;
 
 import com.tarinoita.solsweetpotato.SOLSweetPotato;
 import com.tarinoita.solsweetpotato.item.foodcontainer.FoodContainerItem;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegisterEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryObject;
 
-import static net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus.MOD;
-
-@Mod.EventBusSubscriber(modid = SOLSweetPotato.MOD_ID, bus = MOD)
 public final class SOLSweetPotatoItems
 {
+	public static final DeferredRegister<Item> REGISTER = DeferredRegister.create(ForgeRegistries.ITEMS, SOLSweetPotato.MOD_ID);
 
-	@SubscribeEvent
-	public static void registerItems(RegisterEvent event) {
-		event.register(ForgeRegistries.Keys.ITEMS,
-				helper -> {
-					helper.register(new ResourceLocation(SOLSweetPotato.MOD_ID, "food_book"),
-							new FoodBookItem());
-					helper.register(new ResourceLocation(SOLSweetPotato.MOD_ID, "lunchbox"),
-							new FoodContainerItem(9,"lunchbox"));
-					helper.register(new ResourceLocation(SOLSweetPotato.MOD_ID, "lunchbag"),
-							new FoodContainerItem(5,"lunchbag"));
-					helper.register(new ResourceLocation(SOLSweetPotato.MOD_ID, "golden_lunchbox"),
-							new FoodContainerItem(14,"golden_lunchbox"));
-				});
-	}
+	public static final RegistryObject<FoodBookItem> FOOD_BOOK = REGISTER.register("food_book", FoodBookItem::new);
+	public static final RegistryObject<FoodContainerItem> LUNCHBOX = REGISTER.register("lunchbox", () -> new FoodContainerItem(9,"lunchbox"));
+	public static final RegistryObject<FoodContainerItem> LUNCHBAG = REGISTER.register("lunchbag", () -> new FoodContainerItem(5,"lunchbag"));
+	public static final RegistryObject<FoodContainerItem> GOLDEN_LUNCHBOX = REGISTER.register("golden_lunchbox", () -> new FoodContainerItem(14,"golden_lunchbox"));
 }


### PR DESCRIPTION
Changes the way items are registered (using a DeferredRegistry), and registers those items to the Foodstuffs creative tab. This means that recipe viewers like JEI, EMI, and REI can actually see the items. This would resolve #20 and #9.